### PR TITLE
SatoshiSpritz Friuli

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Partiamo!
             - https://www.meetup.com/Pisa-Bitcoin-Meetup/
         - Roma
             - Satoshi Spritz romano: https://t.me/satoshispritzroma
+        - Friuli
+            - Satoshi Spritz friulano: https://t.me/SatoshiSpritzFriuli
         
         
 


### PR DESCRIPTION
Aggiunto link SatoshiSpritz Friuli.
Proporrei, vista la crescita dei luoghi, di creare una sezione "3e - SatoshiSpritz". Ormai sono già Torino, Milano, Roma, Veneto (per ora Padova, ma si pensa a un'eventuale turnazione, vista la vastità del territorio) e Friuli (in via di definizione). Potrebbe nel tempo diventare sempre più strutturato e meritare una sezione per sé